### PR TITLE
Add kaomoji at start of responses to mitigate abuse

### DIFF
--- a/flipper.py
+++ b/flipper.py
@@ -18,6 +18,6 @@ def roll(bot, trigger):
         hill = False
     tegrat = transform(target)
     if hill:
-        bot.say("%s %s %s %s %s (@_@;)" % (tegrat, target, tegrat, target, tegrat))
+        bot.say("(╮°-°)╯︵ %s %s %s %s %s (@_@;)" % (tegrat, target, tegrat, target, tegrat))
     else:
-        bot.say(tegrat)
+        bot.say("(╮°-°)╯︵ %s" % tegrat)


### PR DESCRIPTION
See #1... Users love loopholes, especially when the bot shouldn't even have access to fantasy commands.