### PR TITLE
Package-ize plugin and update for Sopel 7.1+ only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,23 @@
+
+  Eiffel Forum License, version 2
+
+   1. Permission is hereby granted to use, copy, modify and/or
+      distribute this package, provided that:
+          * copyright notices are retained unchanged,
+          * any distribution of this package, whether modified or not,
+      includes this license text.
+   2. Permission is hereby also granted to distribute binary programs
+      which depend on this package. If the binary program depends on a
+      modified version of this package, you are encouraged to publicly
+      release the modified version of this package.
+
+***********************
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT WARRANTY. ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS PACKAGE.
+
+***********************

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include NEWS
+include COPYING
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# sopel-flipper
+
+A Sopel plugin that flips text in response to CTCP ACTIONs.
+
+## Installing
+
+Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
+
+```shell
+$ pip install sopel-flipper
+```
+
+## Using
+
+Flip or roll text with a CTCP ACTION (`/me` command) and Sopel will output the
+transformed text along with an appropriate _kaomoji_.
+
+Try `/me flips a table` or `/me rolls xnaas down a hill` for Easter eggs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = sopel-flipper
+version = 0.1.0
+description = A Sopel plugin that flips text in response to CTCP ACTIONs.
+author = dgw
+author_email = dgw@technobabbl.es
+url = https://github.com/dgw/sopel-flipper
+license = Eiffel Forum License, version 2
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: Eiffel Forum License (EFL)
+    License :: OSI Approved :: Eiffel Forum License
+    Topic :: Communications :: Chat :: Internet Relay Chat
+
+[options]
+packages = find:
+zip_safe = false
+include_package_data = true
+install_requires =
+    sopel>=7.1,<9
+    upsidedown
+
+[options.entry_points]
+sopel.plugins =
+    flipper = sopel_flipper

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import os
+import sys
+from setuptools import setup, find_packages
+
+
+if __name__ == '__main__':
+    print('Sopel does not correctly load plugins installed with setup.py '
+          'directly. Please use "pip install .", or add '
+          '{}/sopel_flipper to core.extra in your config.'
+          .format(os.path.dirname(os.path.abspath(__file__))),
+          file=sys.stderr)
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+with open('NEWS') as history_file:
+    history = history_file.read()
+
+
+setup(
+    long_description=readme + '\n\n' + history,
+    long_description_content_type='text/markdown',
+)

--- a/sopel_flipper/__init__.py
+++ b/sopel_flipper/__init__.py
@@ -1,20 +1,26 @@
-# -*- coding: utf-8 -*-
+# coding=utf8
+"""sopel-flipper
 
-from __future__ import unicode_literals
+A Sopel plugin that flips text in response to CTCP ACTIONs.
+"""
+from __future__ import unicode_literals, absolute_import, division, print_function
+
 from upsidedown import transform
-from sopel.module import intent, rule
 
-@rule('^flips (.+)')
-@intent('ACTION')
+from sopel import plugin
+
+
+@plugin.rule('^flips (.+)')
+@plugin.ctcp
 def flips(bot, trigger):
     target = trigger.group(1).strip()
-    if target == 'a table':
+    if target in ['a table', 'the table']:
         bot.say("(╯°□°）╯︵ ┻━┻")
     else:
         bot.say("(╯°□°）╯︵ %s" % transform(target))
 
-@rule('^rolls (.+)')
-@intent('ACTION')
+@plugin.rule('^rolls (.+)')
+@plugin.ctcp
 def roll(bot, trigger):
     target = trigger.group(1).strip()
     if target.endswith(' down a hill'):


### PR DESCRIPTION
We're specifying dependencies and future-proofing the code.

- Proper package structure in the entrypoint style
- Use `sopel.plugin` instead of `sopel.module`
- Switch from `intent` to `ctcp` decorator